### PR TITLE
Update AssemblyVersion to match PackageVersion to insure installers, …

### DIFF
--- a/GrpcDotNetNamedPipes/GrpcDotNetNamedPipes.csproj
+++ b/GrpcDotNetNamedPipes/GrpcDotNetNamedPipes.csproj
@@ -5,9 +5,9 @@
         <LangVersion>8</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-        <Version>1.4.4</Version>
-        <PackageVersion>1.4.4</PackageVersion>
-        <AssemblyVersion>1.4.4</AssemblyVersion>
+        <Version>1.4.5</Version>
+        <PackageVersion>1.4.5</PackageVersion>
+        <AssemblyVersion>1.4.5</AssemblyVersion>
 
         <Authors>Ben Olden-Cooligan</Authors>
         <Company>Google</Company>

--- a/GrpcDotNetNamedPipes/GrpcDotNetNamedPipes.csproj
+++ b/GrpcDotNetNamedPipes/GrpcDotNetNamedPipes.csproj
@@ -7,7 +7,7 @@
 
         <Version>1.4.4</Version>
         <PackageVersion>1.4.4</PackageVersion>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <AssemblyVersion>1.4.4</AssemblyVersion>
 
         <Authors>Ben Olden-Cooligan</Authors>
         <Company>Google</Company>


### PR DESCRIPTION
…GAC, etc do not pin to outdated/fixed file version v1.0.0.0

Auto tests for our product started failing with:

System.IO.FileNotFoundException: Could not load file or assembly 'GrpcDotNetNamedPipes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=a01056665c7647b7' or one of its dependencies. The system cannot find the file specified.

after updating Nuget package version of GrpcDotNetNamedPipes from 1.4.2 to 1.4.4