### PR TITLE
Ensure trailers are added to calls that throw

### DIFF
--- a/GrpcDotNetNamedPipes.Tests/GrpcNamedPipeTests.cs
+++ b/GrpcDotNetNamedPipes.Tests/GrpcNamedPipeTests.cs
@@ -104,6 +104,18 @@ namespace GrpcDotNetNamedPipes.Tests
 
         [Theory]
         [ClassData(typeof(MultiChannelClassData))]
+        public async Task ThrowingUnaryWithTrailers(ChannelContextFactory factory)
+        {
+            using var ctx = factory.Create();
+            var responseTask = ctx.Client.ThrowingUnaryWithTrailersAsync(new RequestMessage { Value = 10 });
+            var exception = await Assert.ThrowsAsync<RpcException>(async () => await responseTask);
+            Assert.Equal(StatusCode.Unknown, exception.StatusCode);
+            Assert.Equal("test value", exception.Trailers.Get("test-key").Value);
+            Assert.Equal("Exception was thrown by handler.", exception.Status.Detail);
+        }
+
+        [Theory]
+        [ClassData(typeof(MultiChannelClassData))]
         public async Task ThrowCanceledExceptionUnary(ChannelContextFactory factory)
         {
             using var ctx = factory.Create();

--- a/GrpcDotNetNamedPipes.Tests/TestService.proto
+++ b/GrpcDotNetNamedPipes.Tests/TestService.proto
@@ -22,6 +22,7 @@ service TestService {
     rpc SimpleUnary (RequestMessage) returns (ResponseMessage) {}
     rpc DelayedUnary (RequestMessage) returns (ResponseMessage) {}
     rpc ThrowingUnary (RequestMessage) returns (ResponseMessage) {}
+    rpc ThrowingUnaryWithTrailers (RequestMessage) returns (ResponseMessage) {}
     rpc DelayedThrowingUnary (RequestMessage) returns (ResponseMessage) {}
     rpc ClientStreaming (stream RequestMessage) returns (ResponseMessage) {}
     rpc ServerStreaming (RequestMessage) returns (stream ResponseMessage) {}

--- a/GrpcDotNetNamedPipes.Tests/TestServiceImpl.cs
+++ b/GrpcDotNetNamedPipes.Tests/TestServiceImpl.cs
@@ -50,6 +50,12 @@ namespace GrpcDotNetNamedPipes.Tests
             throw ExceptionToThrow;
         }
 
+        public override Task<ResponseMessage> ThrowingUnaryWithTrailers(RequestMessage request, ServerCallContext context)
+        {
+            context.ResponseTrailers.Add("test-key", "test value");
+            throw ExceptionToThrow;
+        }
+
         public override async Task<ResponseMessage> DelayedThrowingUnary(RequestMessage request,
             ServerCallContext context)
         {

--- a/GrpcDotNetNamedPipes/Internal/ClientConnectionContext.cs
+++ b/GrpcDotNetNamedPipes/Internal/ClientConnectionContext.cs
@@ -108,7 +108,7 @@ namespace GrpcDotNetNamedPipes.Internal
             }
             else
             {
-                _payloadQueue.SetError(new RpcException(status));
+                _payloadQueue.SetError(new RpcException(status, _responseTrailers));
             }
         }
 


### PR DESCRIPTION
I was adding C# exception details to trailers and throwing an `RpcException` in the service handler and discovered that the trailers were not being included in the `RpcExpection` that was thrown by the client's call. The trailers are included in the payload over the named pipe but were missing in the exception.