### PR TITLE
Feature/enhance logging

### DIFF
--- a/GrpcDotNetNamedPipes.PerfTests/GrpcDotNetNamedPipes.PerfTests.csproj
+++ b/GrpcDotNetNamedPipes.PerfTests/GrpcDotNetNamedPipes.PerfTests.csproj
@@ -10,8 +10,11 @@
 
     <ItemGroup>
         <PackageReference Include="Grpc.AspNetCore" Version="2.49.0" Condition="'$(TargetFramework)' != 'net462'" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/GrpcDotNetNamedPipes.Tests/GrpcDotNetNamedPipes.Tests.csproj
+++ b/GrpcDotNetNamedPipes.Tests/GrpcDotNetNamedPipes.Tests.csproj
@@ -9,14 +9,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.21.9" />
-        <PackageReference Include="Grpc" Version="2.46.5" />
-        <PackageReference Include="Grpc.Core.Api" Version="2.49.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.50.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Google.Protobuf" Version="3.24.3" />
+        <PackageReference Include="Grpc" Version="2.46.6" />
+        <PackageReference Include="Grpc.Core.Api" Version="2.57.0" />
+        <PackageReference Include="Grpc.Tools" Version="2.58.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/GrpcDotNetNamedPipes.Tests/Helpers/NamedPipeChannelContextFactory.cs
+++ b/GrpcDotNetNamedPipes.Tests/Helpers/NamedPipeChannelContextFactory.cs
@@ -24,7 +24,7 @@ public class NamedPipeChannelContextFactory : ChannelContextFactory
     public ChannelContext Create(NamedPipeServerOptions options, ITestOutputHelper output)
     {
         var impl = new TestServiceImpl();
-        var server = new NamedPipeServer(_pipeName, options, output != null ? output.WriteLine : null);
+        var server = new NamedPipeServer(_pipeName, options, output != null ? output.WriteLine : null, output != null ? output.WriteLine : null);
         TestService.BindService(server.ServiceBinder, impl);
         server.Start();
         return new ChannelContext
@@ -44,6 +44,7 @@ public class NamedPipeChannelContextFactory : ChannelContextFactory
     {
         var channel = new NamedPipeChannel(".", _pipeName,
             new NamedPipeChannelOptions { ConnectionTimeout = _connectionTimeout },
+            output != null ? output.WriteLine : null, 
             output != null ? output.WriteLine : null);
         channel.PipeCallback = PipeCallback;
         return new TestService.TestServiceClient(channel);

--- a/GrpcDotNetNamedPipes/GrpcDotNetNamedPipes.csproj
+++ b/GrpcDotNetNamedPipes/GrpcDotNetNamedPipes.csproj
@@ -5,8 +5,8 @@
         <LangVersion>11</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-        <Version>2.1.0</Version>
-        <PackageVersion>2.1.0</PackageVersion>
+        <Version>2.2.0</Version>
+        <PackageVersion>2.2.0</PackageVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
 
         <Authors>Ben Olden-Cooligan</Authors>
@@ -25,9 +25,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.21.9" />
-        <PackageReference Include="Grpc.Core.Api" Version="2.49.0" />
-        <PackageReference Include="Grpc.Tools" Version="2.50.0" PrivateAssets="All" />
+        <PackageReference Include="Google.Protobuf" Version="3.24.3" />
+        <PackageReference Include="Grpc.Core.Api" Version="2.57.0" />
+        <PackageReference Include="Grpc.Tools" Version="2.58.0" PrivateAssets="All" />
         <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" Condition="'$(TargetFramework)' == 'net5.0-windows'" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
     </ItemGroup>

--- a/GrpcDotNetNamedPipes/Internal/Helpers/ConnectionLogger.cs
+++ b/GrpcDotNetNamedPipes/Internal/Helpers/ConnectionLogger.cs
@@ -21,15 +21,17 @@ internal class ConnectionLogger
     private static int _lastId;
 
     private static int NextId() => Interlocked.Increment(ref _lastId);
-    public static ConnectionLogger Client(Action<string> log) => new(log, "CLIENT", log != null ? NextId() : 0);
-    public static ConnectionLogger Server(Action<string> log) => new(log, "SERVER", 0);
+    public static ConnectionLogger Client(Action<string> traceLog, Action<string> errorLog) => new(traceLog, errorLog, "CLIENT", traceLog != null ? NextId() : 0);
+    public static ConnectionLogger Server(Action<string> traceLog, Action<string> errorLog) => new(traceLog, errorLog, "SERVER", 0);
 
-    private readonly Action<string> _log;
+    private readonly Action<string> _traceLog;
+    private readonly Action<string> _errorLog;
     private readonly string _type;
 
-    private ConnectionLogger(Action<string> log, string type, int id)
+    private ConnectionLogger(Action<string> traceLog, Action<string> errorLog, string type, int id)
     {
-        _log = log;
+        _traceLog = traceLog;
+        _errorLog = errorLog;
         _type = type;
         ConnectionId = id;
     }
@@ -38,8 +40,15 @@ internal class ConnectionLogger
 
     public void Log(string message)
     {
-        if (_log == null) return;
+        if (_traceLog == null) return;
         var id = ConnectionId > 0 ? ConnectionId.ToString() : "?";
-        _log($"[{_type}][{id}] {message}");
+        _traceLog($"[{_type}][{id}] {message}");
+    }
+   
+    public void LogError(string message)
+    {
+        if(_errorLog == null) return;
+        var id = ConnectionId > 0 ? ConnectionId.ToString() : "?";
+        _errorLog($"[{_type}][{id}] {message}");
     }
 }

--- a/GrpcDotNetNamedPipes/Internal/PipeReader.cs
+++ b/GrpcDotNetNamedPipes/Internal/PipeReader.cs
@@ -49,11 +49,11 @@ internal class PipeReader
         }
         catch (EndOfPipeException)
         {
-            _logger.Log("End of pipe");
+            _logger.LogError("End of pipe");
         }
         catch (Exception error)
         {
-            _logger.Log("Pipe read error");
+            _logger.LogError("Pipe read error");
             _onError?.Invoke(error);
         }
         finally

--- a/GrpcDotNetNamedPipes/Internal/ServerStreamPool.cs
+++ b/GrpcDotNetNamedPipes/Internal/ServerStreamPool.cs
@@ -161,7 +161,8 @@ internal class ServerStreamPool : IDisposable
             try
             {
                 await _handleConnection(pipeServer);
-                pipeServer.Disconnect();
+                if (pipeServer.IsConnected)
+                    pipeServer.Disconnect();
             }
             catch (Exception error)
             {

--- a/GrpcDotNetNamedPipes/Internal/ServerStreamPool.cs
+++ b/GrpcDotNetNamedPipes/Internal/ServerStreamPool.cs
@@ -18,7 +18,7 @@ namespace GrpcDotNetNamedPipes.Internal;
 
 internal class ServerStreamPool : IDisposable
 {
-    private const int PoolSize = 4;
+    private readonly int PoolSize = 4;
     private const int FallbackMin = 100;
     private const int FallbackMax = 10_000;
 
@@ -37,6 +37,8 @@ internal class ServerStreamPool : IDisposable
         _options = options;
         _handleConnection = handleConnection;
         _invokeError = invokeError;
+        if (options.ThreadPoolSize > 0)
+            PoolSize = options.ThreadPoolSize;
     }
 
     private NamedPipeServerStream CreatePipeServer()

--- a/GrpcDotNetNamedPipes/NamedPipeChannel.cs
+++ b/GrpcDotNetNamedPipes/NamedPipeChannel.cs
@@ -22,6 +22,7 @@ public class NamedPipeChannel : CallInvoker
     private readonly string _pipeName;
     private readonly NamedPipeChannelOptions _options;
     private readonly Action<string> _log;
+    private readonly Action<string> _errorLog;
 
     public NamedPipeChannel(string serverName, string pipeName)
         : this(serverName, pipeName, new NamedPipeChannelOptions())
@@ -29,16 +30,17 @@ public class NamedPipeChannel : CallInvoker
     }
 
     public NamedPipeChannel(string serverName, string pipeName, NamedPipeChannelOptions options)
-        : this(serverName, pipeName, options, null)
+        : this(serverName, pipeName, options, null, null)
     {
     }
 
-    internal NamedPipeChannel(string serverName, string pipeName, NamedPipeChannelOptions options, Action<string> log)
+    public NamedPipeChannel(string serverName, string pipeName, NamedPipeChannelOptions options, Action<string> log, Action<string> errorLog)
     {
         _serverName = serverName;
         _pipeName = pipeName;
         _options = options;
         _log = log;
+        _errorLog = errorLog;
     }
 
     internal Action<NamedPipeClientStream> PipeCallback { get; set; }
@@ -62,7 +64,7 @@ public class NamedPipeChannel : CallInvoker
         try
         {
             bool isServerUnary = method.Type == MethodType.Unary || method.Type == MethodType.ClientStreaming;
-            var logger = ConnectionLogger.Client(_log);
+            var logger = ConnectionLogger.Client(_log, _errorLog);
             var ctx = new ClientConnectionContext(stream, callOptions, isServerUnary, _options.ConnectionTimeout,
                 logger);
             ctx.InitCall(method, request);

--- a/GrpcDotNetNamedPipes/NamedPipeServerOptions.cs
+++ b/GrpcDotNetNamedPipes/NamedPipeServerOptions.cs
@@ -38,4 +38,10 @@ public class NamedPipeServerOptions
     /// by using TaskCreationOptions.preferFairness
     /// </summary>
     public TaskFactory TaskFactory { get; set; }
+
+    /// <summary>
+    /// Gets or sets a count of threads to use for the listener.
+    /// If you need to address a synchronous code execution issue, try increasing
+    /// </summary>
+    public int ThreadPoolSize { get; set; } = 4;
 }

--- a/GrpcDotNetNamedPipes/NamedPipeServerOptions.cs
+++ b/GrpcDotNetNamedPipes/NamedPipeServerOptions.cs
@@ -31,4 +31,11 @@ public class NamedPipeServerOptions
     /// </summary>
     public PipeSecurity PipeSecurity { get; set; }
 #endif
+
+    /// <summary>
+    /// Gets or sets a Custom Task Factory to control how tasks are serviced. 
+    /// For example, causing threads to be processsed in FIFO rather than LIFO  
+    /// by using TaskCreationOptions.preferFairness
+    /// </summary>
+    public TaskFactory TaskFactory { get; set; }
 }


### PR DESCRIPTION
@cyanfish when debugging my load testing, I found that I needed to enhance the logging and make it accessible.

Please consider this PR, which separates a trace log action from an error log action as two separate targets that can be wired up as the caller needs. It also breaks out the four cases of error in your error handling to provide more specific information.

This as-seen builds up on the other work I did for FIFO and pool size options. If you are okay with this, I'd say merge this and abandon the other PR.
