### PR TITLE
Fix RpcException trailers not propagating to client

### DIFF
--- a/GrpcDotNetNamedPipes.Tests/TestService.proto
+++ b/GrpcDotNetNamedPipes.Tests/TestService.proto
@@ -22,6 +22,7 @@ service TestService {
     rpc SimpleUnary (RequestMessage) returns (ResponseMessage) {}
     rpc DelayedUnary (RequestMessage) returns (ResponseMessage) {}
     rpc ThrowingUnary (RequestMessage) returns (ResponseMessage) {}
+    rpc ThrowingUnaryWithTrailers (RequestMessage) returns (ResponseMessage) {}
     rpc DelayedThrowingUnary (RequestMessage) returns (ResponseMessage) {}
     rpc ClientStreaming (stream RequestMessage) returns (ResponseMessage) {}
     rpc ServerStreaming (RequestMessage) returns (stream ResponseMessage) {}

--- a/GrpcDotNetNamedPipes.Tests/TestServiceImpl.cs
+++ b/GrpcDotNetNamedPipes.Tests/TestServiceImpl.cs
@@ -45,6 +45,12 @@ public class TestServiceImpl : TestService.TestServiceBase
         throw ExceptionToThrow;
     }
 
+    public override Task<ResponseMessage> ThrowingUnaryWithTrailers(RequestMessage request, ServerCallContext context)
+    {
+        context.ResponseTrailers.Add("test-key", "test value");
+        throw ExceptionToThrow;
+    }
+
     public override async Task<ResponseMessage> DelayedThrowingUnary(RequestMessage request,
         ServerCallContext context)
     {

--- a/GrpcDotNetNamedPipes/Internal/ClientConnectionContext.cs
+++ b/GrpcDotNetNamedPipes/Internal/ClientConnectionContext.cs
@@ -103,7 +103,7 @@ internal class ClientConnectionContext : TransportMessageHandler, IDisposable
         }
         else
         {
-            _payloadQueue.SetError(new RpcException(status));
+            _payloadQueue.SetError(new RpcException(status, _responseTrailers));
         }
     }
 

--- a/GrpcDotNetNamedPipes/Internal/ServerConnectionContext.cs
+++ b/GrpcDotNetNamedPipes/Internal/ServerConnectionContext.cs
@@ -87,6 +87,7 @@ internal class ServerConnectionContext : TransportMessageHandler, IDisposable
         }
         else if (ex is RpcException rpcException)
         {
+            ExtendResponseTrailers(rpcException.Trailers);
             WriteTrailers(rpcException.StatusCode, rpcException.Status.Detail);
         }
         else
@@ -119,6 +120,15 @@ internal class ServerConnectionContext : TransportMessageHandler, IDisposable
     private void WriteTrailers(StatusCode statusCode, string statusDetail)
     {
         Transport.Write().Trailers(statusCode, statusDetail, CallContext.ResponseTrailers).Commit();
+    }
+
+    private void ExtendResponseTrailers(Metadata trailers)
+    {
+        if (trailers == null)
+            return;
+
+        foreach (var entry in trailers)
+            CallContext.ResponseTrailers.Add(entry);
     }
 
     public void Dispose()


### PR DESCRIPTION
I've encountered the same problem as @alexhelms - RpcException trailers are not accessible on the client side. For me this is a major blocker and given that the [Alex's pull request](https://github.com/cyanfish/grpc-dotnet-namedpipes/pull/45) has not been merged yet and doesn't seem to be proceeding at all due to CLA issues I've decided to create another pull request based on Alex's code (I hope Alex doesn't mind). 

However, Alex's code doesn't solve the whole issue for me. Custom trailers are sent to client only if they are put to the ResponseTrailers on the server call context. If there is a custom RpcException thrown on the server side, the trailers stored in the exception are not transferred to the client. I've decided to take the same approach as ASP .NET Core does - adding trailers from the caught RpcException to the server call context before sending it to the client - please see the `void ProcessHandlerError(Exception ex, string method)` method in [HttpContextServerCallContext](https://github.com/grpc/grpc-dotnet/blob/master/src/Grpc.AspNetCore.Server/Internal/HttpContextServerCallContext.cs). The logic works for both unary and streaming calls.