### PR TITLE
Added verification of PipeServer connection state

### DIFF
--- a/GrpcDotNetNamedPipes/Internal/ServerStreamPool.cs
+++ b/GrpcDotNetNamedPipes/Internal/ServerStreamPool.cs
@@ -161,7 +161,8 @@ internal class ServerStreamPool : IDisposable
             try
             {
                 await _handleConnection(pipeServer);
-                pipeServer.Disconnect();
+                if (pipeServer.IsConnected)
+                    pipeServer.Disconnect();
             }
             catch (Exception error)
             {


### PR DESCRIPTION
When testing in a multi-threaded environment with many connections per second, the following error was being generated: Cannot access a closed pipe.

A brief adjustment was made to check the connection status before attempting to close the connection.